### PR TITLE
Fixes #1

### DIFF
--- a/Jekyll/plugins/autotag_gen.rb
+++ b/Jekyll/plugins/autotag_gen.rb
@@ -27,7 +27,7 @@ module Jekyll
       self.process(@name)
       self.read_yaml(File.join(base, '_layouts'), 'tags_json.html')
       tags_with_counts = site.tags.delete_if {|k,v|
-        site.config['tag_excludes'].include?(k)
+        site.config['tag_excludes'].include?(k) unless site.config['tag_excludes'].nil?
       }.sort_by { |k,v| v.count }.reverse
 
       self.data['json_tags'] = tags_with_counts.sort {|a,b| a[0].downcase <=> b[0].downcase }.map {|k,v| k }


### PR DESCRIPTION
Now if plugin gets ran, it won't crash if tag_excludes isn't in the site config.
